### PR TITLE
Hotfix for bug with "else" and "end" on same line causing unwanted indentations

### DIFF
--- a/bin/ruby-beautify
+++ b/bin/ruby-beautify
@@ -4,11 +4,11 @@ require 'ripper'
 require 'optparse'
 
 Options = OptionParser.new do |opts|
-	opts.on("-V", "--version", "Print version") { |version| puts RBeautify::VERSION;exit 0}
-	opts.on("-c", "--indent_count [COUNT]", Integer, "Count of characters to use for indenting. (default: 1)") { |count| @indent_count = count}
-	opts.on("-t", "--tabs", "Use tabs for the indent character (default)") { @indent_token = "\t" }
-	opts.on("-s", "--spaces", "Use spaces for the indent character") { @indent_token = " " }
-	opts.banner = "Usage: print ruby into a pretty format, or break trying."
+  opts.on("-V", "--version", "Print version") { |version| puts RBeautify::VERSION;exit 0}
+  opts.on("-c", "--indent_count [COUNT]", Integer, "Count of characters to use for indenting. (default: 1)") { |count| @indent_count = count}
+  opts.on("-t", "--tabs", "Use tabs for the indent character (default)") { @indent_token = "\t" }
+  opts.on("-s", "--spaces", "Use spaces for the indent character") { @indent_token = " " }
+  opts.banner = "Usage: print ruby into a pretty format, or break trying."
 end
 Options.parse!
 
@@ -25,169 +25,171 @@ Options.parse!
 @indent_count = 1 unless @indent_count
 
 def puts_indented_line(level, string)
-	if string =~ /^\n$/
-		puts
-	else
-		indent = (@indent_token * @indent_count) * level
-		puts "#{indent}#{string.lstrip}"
-	end
+  if string =~ /^\n$/
+    puts
+  else
+    indent = (@indent_token * @indent_count) * level
+    puts "#{indent}#{string.lstrip}"
+  end
 end
 
 def pretty(content)
-	begin
-		lex = Ripper.lex(content)
-	rescue
-		exit 255
-	end
+  begin
+    lex = Ripper.lex(content)
+  rescue
+    exit 255
+  end
 
-	indent_level = 0
-	line_lex = []
+  indent_level = 0
+  line_lex = []
 
-	# walk through line tokens
-	lex.each do |token|
-		line_lex << token
-		if @new_lines.include? token[1] # if type of this token is a new line
+  # walk through line tokens
+  lex.each do |token|
+    line_lex << token
+    if @new_lines.include? token[1] # if type of this token is a new line
 
-			# did we just close something?  if so, lets bring it down a level.
-			if closing_block?(line_lex) || closing_assignment?(line_lex)
-				indent_level -= 1 if indent_level > 0
-			end
+      # did we just close something?  if so, lets bring it down a level.
+      if closing_block?(line_lex) || closing_assignment?(line_lex)
+        indent_level -= 1 if indent_level > 0
+      end
 
-			# print our line, in place.
-			line_string = line_lex.map {|l| l.last}.join
-			puts_indented_line(indent_level, line_string)
+      # print our line, in place.
+      line_string = line_lex.map {|l| l.last}.join
+      puts_indented_line(indent_level, line_string)
 
-			# oh, we opened something did we?  lets indent for the next run.
-			if opening_block?(line_lex) || opening_assignment?(line_lex)
-				indent_level += 1
-			end
+      # oh, we opened something did we?  lets indent for the next run.
+      if opening_block?(line_lex) || opening_assignment?(line_lex)
+        indent_level += 1
+      end
 
-			line_lex.clear
-		end
-	end
+      line_lex.clear
+    end
+  end
 
-	return nil
+  return nil
 end
 
 # how many times do we open in this line?
 def opening_block_count(line_lex)
-	line_lex.select {|l| l[1] == :on_kw && @open_block_do.include?(l[2])}.count
+  line_lex.select {|l| l[1] == :on_kw && @open_block_do.include?(l[2])}.count
 end
 
 # how many times do we close?
 def closing_block_count(line_lex)
-	line_lex.select {|l| l[1] == :on_kw && @close_block.include?(l[2])}.count
+  line_lex.select {|l| l[1] == :on_kw && @close_block.include?(l[2])}.count
 end
 
 # is the first word a key word?
 def starts_block?(line_lex)
-	return true if contains_block_assignment? line_lex
-	line_lex.each do |x|
-		# search for a first non-space token
-		if not x[1] == :on_sp
-			return x[1] == :on_kw && @open_block_start.include?(x[2])
-		end
-	end
+  return true if contains_block_assignment? line_lex
+  line_lex.each do |x|
+    # search for a first non-space token
+    if not x[1] == :on_sp
+      return x[1] == :on_kw && @open_block_start.include?(x[2])
+    end
+  end
 end
 
 # is the first word one of our 'both' keywords?
 def both_block?(line_lex)
-	line_lex.each do |x|
-		# search for a first non-space token
-		if not x[1] == :on_sp
-			return x[1] == :on_kw && @both_block.include?(x[2])
-		end
-	end
+  line_lex.each do |x|
+    # search for a first non-space token
+    if not x[1] == :on_sp
+      return x[1] == :on_kw && @both_block.include?(x[2])
+    end
+  end
 end
 
 # kinda complex, we count open/close to determine if we ultimately have a
 # hanging line.   Always true if it's a both_block.
 def opening_block?(line_lex)
-	line_lex.each do |x|
-		if not x[1] == :on_sp
-			return false if x[1] == :on_kw && @close_block.include?(x[2]) 
-		end
-	end
-	return true if both_block? line_lex
-	opens = starts_block?(line_lex) ? 1 : 0
-	opens += opening_block_count line_lex
-	closes = closing_block_count line_lex
-	return false if opens == closes
-	return true if opens > closes
+  line_lex.each do |x|
+    if not x[1] == :on_sp
+      return false if x[1] == :on_kw && @close_block.include?(x[2]) 
+    end
+  end
+  return true if both_block? line_lex
+  opens = starts_block?(line_lex) ? 1 : 0
+  opens += opening_block_count line_lex
+  closes = closing_block_count line_lex
+  return false if opens == closes
+  return true if opens > closes
 end
 
 # kinda complex, we count open/close to determine if we ultimately have close a
 # hanging line.   Always true if it's a both_block.
 def closing_block?(line_lex)
-	return true if both_block? line_lex
-	opens = starts_block?(line_lex) ? 1 : 0
-	opens += opening_block_count line_lex
-	closes = closing_block_count line_lex
-	return false if opens == closes
-	return true if opens < closes
+  return true if both_block? line_lex
+  opens = starts_block?(line_lex) ? 1 : 0
+  opens += opening_block_count line_lex
+  closes = closing_block_count line_lex
+  return false if opens == closes
+  return true if opens < closes
 end
 
 # count the amount of opening assignments.
 def opening_assignment_count(line_lex)
-	line_lex.select {|l| @open_brackets.include? l[1]}.count
+  line_lex.select {|l| @open_brackets.include? l[1]}.count
 end
 
 # count the amount of closing assignments.
 def closing_assignment_count(line_lex)
-	line_lex.select {|l| @close_brackets.include? l[1]}.count
+  line_lex.select {|l| @close_brackets.include? l[1]}.count
 end
 
 # same trick as opening_block
 def opening_assignment?(line_lex)
-	opens = opening_assignment_count line_lex
-	closes = closing_assignment_count line_lex
-	return false if opens == closes
-	return true if opens > closes
+  opens = opening_assignment_count line_lex
+  closes = closing_assignment_count line_lex
+  return false if opens == closes
+  return true if opens > closes
 end
 
 # ...
 def closing_assignment?(line_lex)
-	opens = opening_assignment_count line_lex
-	closes = closing_assignment_count line_lex
-	return false if opens == closes
-	return true if closes > opens
+  opens = opening_assignment_count line_lex
+  closes = closing_assignment_count line_lex
+  return false if opens == closes
+  return true if closes > opens
 end
 
 # test for assignment from a block
 def contains_block_assignment?(line_lex)
-	compacted_line = line_lex.reject{|x| x[1] == :on_sp} #remove spaces
-	idx = compacted_line.rindex{|x| ['=', '||='].include? x[2]} #find last equal
-	if idx
-		return @open_block_start.include?(compacted_line[idx+1][2]) #check for if/begin block
-	end
-	return false
+  compacted_line = line_lex.reject{|x| x[1] == :on_sp} #remove spaces
+  idx = compacted_line.rindex{|x| ['=', '||='].include? x[2]} #find last equal
+  if idx
+    return @open_block_start.include?(compacted_line[idx+1][2]) #check for if/begin block
+  end
+  return false
 end
 
 # is this ruby file valid syntax?
 def valid_syntax?(file)
-	#ugly but fast, ruby returns stdout if it's ok, and stderr if not.
-	#if we get anything back, we were ok, else we were not.
-	r = `ruby -c #{file} 2> /dev/null`
-	return false if r == ""
-	return true
+  #ugly but fast, ruby returns stdout if it's ok, and stderr if not.
+  #if we get anything back, we were ok, else we were not.
+  r = `ruby -c #{file} 2> /dev/null`
+  return false if r == ""
+  return true
 end
 
 # no argument, assume we want to open STDIN.
 if ARGV.empty?
-	content = $stdin.read
-	puts pretty content
+  content = $stdin.read
+  puts pretty content
 else
-	file = ARGV[0]
-	if File.exist? file
-		if valid_syntax? file
-			content = open(file).read
-			pretty content
-		else
-			puts content
-			exit 127
-		end
-	else
-		puts "No such file: #{file}"
-	end
+  file = ARGV[0]
+  if File.exist? file
+    if valid_syntax? file
+      content = open(file).read
+      pretty content
+    else
+      puts content
+      exit 127
+    end
+  else
+    puts "No such file: #{file}"
+  end
 end
+
+
 

--- a/bin/ruby-beautify
+++ b/bin/ruby-beautify
@@ -4,11 +4,11 @@ require 'ripper'
 require 'optparse'
 
 Options = OptionParser.new do |opts|
-  opts.on("-V", "--version", "Print version") { |version| puts RBeautify::VERSION;exit 0}
-  opts.on("-c", "--indent_count [COUNT]", Integer, "Count of characters to use for indenting. (default: 1)") { |count| @indent_count = count}
-  opts.on("-t", "--tabs", "Use tabs for the indent character (default)") { @indent_token = "\t" }
-  opts.on("-s", "--spaces", "Use spaces for the indent character") { @indent_token = " " }
-  opts.banner = "Usage: print ruby into a pretty format, or break trying."
+	opts.on("-V", "--version", "Print version") { |version| puts RBeautify::VERSION;exit 0}
+	opts.on("-c", "--indent_count [COUNT]", Integer, "Count of characters to use for indenting. (default: 1)") { |count| @indent_count = count}
+	opts.on("-t", "--tabs", "Use tabs for the indent character (default)") { @indent_token = "\t" }
+	opts.on("-s", "--spaces", "Use spaces for the indent character") { @indent_token = " " }
+	opts.banner = "Usage: print ruby into a pretty format, or break trying."
 end
 Options.parse!
 
@@ -25,163 +25,169 @@ Options.parse!
 @indent_count = 1 unless @indent_count
 
 def puts_indented_line(level, string)
-  if string =~ /^\n$/
-    puts
-  else
-    indent = (@indent_token * @indent_count) * level
-    puts "#{indent}#{string.lstrip}"
-  end
+	if string =~ /^\n$/
+		puts
+	else
+		indent = (@indent_token * @indent_count) * level
+		puts "#{indent}#{string.lstrip}"
+	end
 end
 
 def pretty(content)
-  begin
-    lex = Ripper.lex(content)
-  rescue
-    exit 255
-  end
+	begin
+		lex = Ripper.lex(content)
+	rescue
+		exit 255
+	end
 
-  indent_level = 0
-  line_lex = []
+	indent_level = 0
+	line_lex = []
 
-  # walk through line tokens
-  lex.each do |token|
-    line_lex << token
-    if @new_lines.include? token[1] # if type of this token is a new line
+	# walk through line tokens
+	lex.each do |token|
+		line_lex << token
+		if @new_lines.include? token[1] # if type of this token is a new line
 
-      # did we just close something?  if so, lets bring it down a level.
-      if closing_block?(line_lex) || closing_assignment?(line_lex)
-        indent_level -= 1 if indent_level > 0
-      end
+			# did we just close something?  if so, lets bring it down a level.
+			if closing_block?(line_lex) || closing_assignment?(line_lex)
+				indent_level -= 1 if indent_level > 0
+			end
 
-      # print our line, in place.
-      line_string = line_lex.map {|l| l.last}.join
-      puts_indented_line(indent_level, line_string)
+			# print our line, in place.
+			line_string = line_lex.map {|l| l.last}.join
+			puts_indented_line(indent_level, line_string)
 
-      # oh, we opened something did we?  lets indent for the next run.
-      if opening_block?(line_lex) || opening_assignment?(line_lex)
-        indent_level += 1
-      end
+			# oh, we opened something did we?  lets indent for the next run.
+			if opening_block?(line_lex) || opening_assignment?(line_lex)
+				indent_level += 1
+			end
 
-      line_lex.clear
-    end
-  end
+			line_lex.clear
+		end
+	end
 
-  return nil
+	return nil
 end
 
 # how many times do we open in this line?
 def opening_block_count(line_lex)
-  line_lex.select {|l| l[1] == :on_kw && @open_block_do.include?(l[2])}.count
+	line_lex.select {|l| l[1] == :on_kw && @open_block_do.include?(l[2])}.count
 end
 
 # how many times do we close?
 def closing_block_count(line_lex)
-  line_lex.select {|l| l[1] == :on_kw && @close_block.include?(l[2])}.count
+	line_lex.select {|l| l[1] == :on_kw && @close_block.include?(l[2])}.count
 end
 
 # is the first word a key word?
 def starts_block?(line_lex)
-  return true if contains_block_assignment? line_lex
-  line_lex.each do |x|
-    # search for a first non-space token
-    if not x[1] == :on_sp
-      return x[1] == :on_kw && @open_block_start.include?(x[2])
-    end
-  end
+	return true if contains_block_assignment? line_lex
+	line_lex.each do |x|
+		# search for a first non-space token
+		if not x[1] == :on_sp
+			return x[1] == :on_kw && @open_block_start.include?(x[2])
+		end
+	end
 end
 
 # is the first word one of our 'both' keywords?
 def both_block?(line_lex)
-  line_lex.each do |x|
-    # search for a first non-space token
-    if not x[1] == :on_sp
-      return x[1] == :on_kw && @both_block.include?(x[2])
-    end
-  end
+	line_lex.each do |x|
+		# search for a first non-space token
+		if not x[1] == :on_sp
+			return x[1] == :on_kw && @both_block.include?(x[2])
+		end
+	end
 end
 
 # kinda complex, we count open/close to determine if we ultimately have a
 # hanging line.   Always true if it's a both_block.
 def opening_block?(line_lex)
-  return true if both_block? line_lex
-  opens = starts_block?(line_lex) ? 1 : 0
-  opens += opening_block_count line_lex
-  closes = closing_block_count line_lex
-  return false if opens == closes
-  return true if opens > closes
+	line_lex.each do |x|
+		if not x[1] == :on_sp
+			return false if x[1] == :on_kw && @close_block.include?(x[2]) 
+		end
+	end
+	return true if both_block? line_lex
+	opens = starts_block?(line_lex) ? 1 : 0
+	opens += opening_block_count line_lex
+	closes = closing_block_count line_lex
+	return false if opens == closes
+	return true if opens > closes
 end
 
 # kinda complex, we count open/close to determine if we ultimately have close a
 # hanging line.   Always true if it's a both_block.
 def closing_block?(line_lex)
-  return true if both_block? line_lex
-  opens = starts_block?(line_lex) ? 1 : 0
-  opens += opening_block_count line_lex
-  closes = closing_block_count line_lex
-  return false if opens == closes
-  return true if opens < closes
+	return true if both_block? line_lex
+	opens = starts_block?(line_lex) ? 1 : 0
+	opens += opening_block_count line_lex
+	closes = closing_block_count line_lex
+	return false if opens == closes
+	return true if opens < closes
 end
 
 # count the amount of opening assignments.
 def opening_assignment_count(line_lex)
-  line_lex.select {|l| @open_brackets.include? l[1]}.count
+	line_lex.select {|l| @open_brackets.include? l[1]}.count
 end
 
 # count the amount of closing assignments.
 def closing_assignment_count(line_lex)
-  line_lex.select {|l| @close_brackets.include? l[1]}.count
+	line_lex.select {|l| @close_brackets.include? l[1]}.count
 end
 
 # same trick as opening_block
 def opening_assignment?(line_lex)
-  opens = opening_assignment_count line_lex
-  closes = closing_assignment_count line_lex
-  return false if opens == closes
-  return true if opens > closes
+	opens = opening_assignment_count line_lex
+	closes = closing_assignment_count line_lex
+	return false if opens == closes
+	return true if opens > closes
 end
 
 # ...
 def closing_assignment?(line_lex)
-  opens = opening_assignment_count line_lex
-  closes = closing_assignment_count line_lex
-  return false if opens == closes
-  return true if closes > opens
+	opens = opening_assignment_count line_lex
+	closes = closing_assignment_count line_lex
+	return false if opens == closes
+	return true if closes > opens
 end
 
 # test for assignment from a block
 def contains_block_assignment?(line_lex)
-  compacted_line = line_lex.reject{|x| x[1] == :on_sp} #remove spaces
-  idx = compacted_line.rindex{|x| ['=', '||='].include? x[2]} #find last equal
-  if idx
-    return @open_block_start.include?(compacted_line[idx+1][2]) #check for if/begin block
-  end
-  return false
+	compacted_line = line_lex.reject{|x| x[1] == :on_sp} #remove spaces
+	idx = compacted_line.rindex{|x| ['=', '||='].include? x[2]} #find last equal
+	if idx
+		return @open_block_start.include?(compacted_line[idx+1][2]) #check for if/begin block
+	end
+	return false
 end
 
 # is this ruby file valid syntax?
 def valid_syntax?(file)
-  #ugly but fast, ruby returns stdout if it's ok, and stderr if not.
-  #if we get anything back, we were ok, else we were not.
-  r = `ruby -c #{file} 2> /dev/null`
-  return false if r == ""
-  return true
+	#ugly but fast, ruby returns stdout if it's ok, and stderr if not.
+	#if we get anything back, we were ok, else we were not.
+	r = `ruby -c #{file} 2> /dev/null`
+	return false if r == ""
+	return true
 end
 
 # no argument, assume we want to open STDIN.
 if ARGV.empty?
-  content = $stdin.read
-  puts pretty content
+	content = $stdin.read
+	puts pretty content
 else
-  file = ARGV[0]
-  if File.exist? file
-    if valid_syntax? file
-      content = open(file).read
-      pretty content
-    else
-      puts content
-      exit 127
-    end
-  else
-    puts "No such file: #{file}"
-  end
+	file = ARGV[0]
+	if File.exist? file
+		if valid_syntax? file
+			content = open(file).read
+			pretty content
+		else
+			puts content
+			exit 127
+		end
+	else
+		puts "No such file: #{file}"
+	end
 end
+

--- a/lib/ruby-beautify/version.rb
+++ b/lib/ruby-beautify/version.rb
@@ -1,3 +1,3 @@
 module RBeautify
-  VERSION = "0.95.0"
+  VERSION ||= "0.95.0"
 end

--- a/lib/ruby-beautify/version.rb
+++ b/lib/ruby-beautify/version.rb
@@ -1,3 +1,3 @@
 module RBeautify
-  VERSION ||= "0.95.0"
+  VERSION = "0.95.0"
 end

--- a/spec/example.rb
+++ b/spec/example.rb
@@ -1,146 +1,154 @@
 require 'ripper'
 
 module Here
-class There
-def why?(argument = nil)
-@array = [
-1,
-2,
-3
-]
-hash = {
-one:1,
-two:2,
-three:3
-}
-end
+	class There
+		def why?(argument = nil)
+			@array = [
+				1,
+				2,
+				3
+			]
+			hash = {
+				one:1,
+				two:2,
+				three:3
+			}
+		end
 
-# a comment
-def why_not?(argument: {})
-@array = [4,5,6]
-hash = {four:4, five:5, six:6}
-s = "a #{"complex"} string."
-end
+		# a comment
+		def why_not?(argument: {})
+			@array = [4,5,6]
+			hash = {four:4, five:5, six:6}
+			s = "a #{"complex"} string."
+		end
 
-def complex_method(one, two, three, four)
-regex = /regex/
-end
+		def complex_method(one, two, three, four)
+			regex = /regex/
+		end
 
-def with_block
-run = Proc.new { |argument| puts arugment }
-run do |arugment|
-puts argument
-end
-end
-end
+		def with_block
+			run = Proc.new { |argument| puts arugment }
+			run do |arugment|
+				puts argument
+			end
+		end
+	end
 end
 
 h = Here::There.new
 
 h.why?({
-here: 'there',
-there: 'here'
+	here: 'there',
+	there: 'here'
 })
 
 h.with_block {
-puts 'yahooie'
+	puts 'yahooie'
 }
 
 
 h.complex_method('asdkjasflkjdglksjglksfgjlfkgjdf',
-'alfkjsdlkfjsflgkjfglk',
-'alfkjsdlkfjsflgkjfglk',
-'alfkjsdlkfjsflgkjfglk'
+	'alfkjsdlkfjsflgkjfglk',
+	'alfkjsdlkfjsflgkjfglk',
+	'alfkjsdlkfjsflgkjfglk'
 )
 
 h.complex_method('asdkjasflkjdglksjglksfgjlfkgjdf',
-'alfkjsdlkfjsflgkjfglk',
-'alfkjsdlkfjsflgkjfglk',
-'alfkjsdlkfjsflgkjfglk'
+	'alfkjsdlkfjsflgkjfglk',
+	'alfkjsdlkfjsflgkjfglk',
+	'alfkjsdlkfjsflgkjfglk'
 ).map do |i|
-i
+	i
 end.map! { |i| i }
 
 if 1 > 0
-puts 'something'
+	puts 'something'
 elsif 1 < 0
-puts 'never!'
+	puts 'never!'
 else
-puts 'not likely.'
+	puts 'not likely.'
 end
 
+#Test for different if statement formatting style(NOTE: it should not change this block)
+if 1 > 0 then puts 'something'
+elsif 1 < 0 then puts 'never!'
+else puts 'not likely.' end
+
+
 # Test for already indented blocks
-    class There2 < There
-    def m1()
-      puts "m1"
-    end
-def m2()
-          puts "m2"
-  end
-        def m3()
-puts "m3"
-        end
-    end
+class There2 < There
+	def m1()
+		puts "m1"
+	end
+	def m2()
+		puts "m2"
+	end
+	def m3()
+		puts "m3"
+	end
+end
 
 # Test for multiline string
 def m (x)
-puts "This is multi-line string. It's line1 \
+	puts "This is multi-line string. It's line1 \
  It's line 2\
               And this is\n line3
      This line should not be mutated"
-puts "This is multi line interpolated string #{
-x
-}"
+	puts "This is multi line interpolated string #{
+		x
+	}"
 end
 
 # Test to validate case statements
 def case_test opts=nil
-case test_case
-when 'Passing'
-call(:pass)
-when 'Failing'
-call(:fail)
-when 'Error'
-call(:error)
+	case test_case
+	when 'Passing'
+		call(:pass)
+	when 'Failing'
+		call(:fail)
+	when 'Error'
+		call(:error)
+	end
 end
-end
+
 
 # Test for variable assignment from an if statement
 @products = if params[:category]
-Category.find(params[:category]).products
+	Category.find(params[:category]).products
 else
-Product.all
+	Product.all
 end
 
 # Test for variable assignment from a block
 response = begin
-if true?
-api_call(test)
-else
-rejected
-end
+	if true?
+		api_call(test)
+	else
+		rejected
+	end
 rescue
-'FALSE'
+	'FALSE'
 end
 
 # Test or-equals
 def expensive_value
-@expensive_value ||= begin
-if conn.active?
-expensive_call
-else
-:none
-end
-end
+	@expensive_value ||= begin
+		if conn.active?
+			expensive_call
+		else
+			:none
+		end
+	end
 end
 
 # Test multiple or-equals
 def expensive_value
-@expensive_value ||= @cached_value ||= begin
-if conn.active?
-expensive_call
-else
-:none
+	@expensive_value ||= @cached_value ||= begin
+		if conn.active?
+			expensive_call
+		else
+			:none
+		end
+	end
 end
-end
-end
+

--- a/spec/example.rb
+++ b/spec/example.rb
@@ -69,11 +69,25 @@ else
 puts 'not likely.'
 end
 
-#Test for different if statement formatting style(NOTE: it should not change this block at all)
+class OneLiners
+	#Test for different if statement formatting style:
+	def no_change
+		if 1 > 0 then puts 'something'
+		elsif 2 < 0 then puts 'never!'
+		else puts 'not likely.' end
+		if 1 > 0 
+			if 1 == 1 then puts 'Hello' end
+		end
+	end
+def change
 if 1 > 0 then puts 'something'
-elsif 2 < 0 then puts 'never!'
-else puts 'not likely.' end
-if 1 > 0 then puts 'something again' end
+	elsif 2 < 0 then puts 'never!'
+ 			else puts 'not likely.' end
+	if 1 > 0 
+	 	if 1 == 1 then puts 'Hello' end
+end
+	end
+end
 
 # Test for already indented blocks
     class There2 < There

--- a/spec/example.rb
+++ b/spec/example.rb
@@ -1,154 +1,146 @@
 require 'ripper'
 
 module Here
-	class There
-		def why?(argument = nil)
-			@array = [
-				1,
-				2,
-				3
-			]
-			hash = {
-				one:1,
-				two:2,
-				three:3
-			}
-		end
+class There
+def why?(argument = nil)
+@array = [
+1,
+2,
+3
+]
+hash = {
+one:1,
+two:2,
+three:3
+}
+end
 
-		# a comment
-		def why_not?(argument: {})
-			@array = [4,5,6]
-			hash = {four:4, five:5, six:6}
-			s = "a #{"complex"} string."
-		end
+# a comment
+def why_not?(argument: {})
+@array = [4,5,6]
+hash = {four:4, five:5, six:6}
+s = "a #{"complex"} string."
+end
 
-		def complex_method(one, two, three, four)
-			regex = /regex/
-		end
+def complex_method(one, two, three, four)
+regex = /regex/
+end
 
-		def with_block
-			run = Proc.new { |argument| puts arugment }
-			run do |arugment|
-				puts argument
-			end
-		end
-	end
+def with_block
+run = Proc.new { |argument| puts arugment }
+run do |arugment|
+puts argument
+end
+end
+end
 end
 
 h = Here::There.new
 
 h.why?({
-	here: 'there',
-	there: 'here'
+here: 'there',
+there: 'here'
 })
 
 h.with_block {
-	puts 'yahooie'
+puts 'yahooie'
 }
 
 
 h.complex_method('asdkjasflkjdglksjglksfgjlfkgjdf',
-	'alfkjsdlkfjsflgkjfglk',
-	'alfkjsdlkfjsflgkjfglk',
-	'alfkjsdlkfjsflgkjfglk'
+'alfkjsdlkfjsflgkjfglk',
+'alfkjsdlkfjsflgkjfglk',
+'alfkjsdlkfjsflgkjfglk'
 )
 
 h.complex_method('asdkjasflkjdglksjglksfgjlfkgjdf',
-	'alfkjsdlkfjsflgkjfglk',
-	'alfkjsdlkfjsflgkjfglk',
-	'alfkjsdlkfjsflgkjfglk'
+'alfkjsdlkfjsflgkjfglk',
+'alfkjsdlkfjsflgkjfglk',
+'alfkjsdlkfjsflgkjfglk'
 ).map do |i|
-	i
+i
 end.map! { |i| i }
 
 if 1 > 0
-	puts 'something'
+puts 'something'
 elsif 1 < 0
-	puts 'never!'
+puts 'never!'
 else
-	puts 'not likely.'
+puts 'not likely.'
 end
-
-#Test for different if statement formatting style(NOTE: it should not change this block)
-if 1 > 0 then puts 'something'
-elsif 1 < 0 then puts 'never!'
-else puts 'not likely.' end
-
 
 # Test for already indented blocks
-class There2 < There
-	def m1()
-		puts "m1"
-	end
-	def m2()
-		puts "m2"
-	end
-	def m3()
-		puts "m3"
-	end
-end
+    class There2 < There
+    def m1()
+      puts "m1"
+    end
+def m2()
+          puts "m2"
+  end
+        def m3()
+puts "m3"
+        end
+    end
 
 # Test for multiline string
 def m (x)
-	puts "This is multi-line string. It's line1 \
+puts "This is multi-line string. It's line1 \
  It's line 2\
               And this is\n line3
      This line should not be mutated"
-	puts "This is multi line interpolated string #{
-		x
-	}"
+puts "This is multi line interpolated string #{
+x
+}"
 end
 
 # Test to validate case statements
 def case_test opts=nil
-	case test_case
-	when 'Passing'
-		call(:pass)
-	when 'Failing'
-		call(:fail)
-	when 'Error'
-		call(:error)
-	end
+case test_case
+when 'Passing'
+call(:pass)
+when 'Failing'
+call(:fail)
+when 'Error'
+call(:error)
 end
-
+end
 
 # Test for variable assignment from an if statement
 @products = if params[:category]
-	Category.find(params[:category]).products
+Category.find(params[:category]).products
 else
-	Product.all
+Product.all
 end
 
 # Test for variable assignment from a block
 response = begin
-	if true?
-		api_call(test)
-	else
-		rejected
-	end
+if true?
+api_call(test)
+else
+rejected
+end
 rescue
-	'FALSE'
+'FALSE'
 end
 
 # Test or-equals
 def expensive_value
-	@expensive_value ||= begin
-		if conn.active?
-			expensive_call
-		else
-			:none
-		end
-	end
+@expensive_value ||= begin
+if conn.active?
+expensive_call
+else
+:none
+end
+end
 end
 
 # Test multiple or-equals
 def expensive_value
-	@expensive_value ||= @cached_value ||= begin
-		if conn.active?
-			expensive_call
-		else
-			:none
-		end
-	end
+@expensive_value ||= @cached_value ||= begin
+if conn.active?
+expensive_call
+else
+:none
 end
-
+end
+end

--- a/spec/example.rb
+++ b/spec/example.rb
@@ -69,6 +69,12 @@ else
 puts 'not likely.'
 end
 
+#Test for different if statement formatting style(NOTE: it should not change this block at all)
+if 1 > 0 then puts 'something'
+elsif 2 < 0 then puts 'never!'
+else puts 'not likely.' end
+if 1 > 0 then puts 'something again' end
+
 # Test for already indented blocks
     class There2 < There
     def m1()

--- a/spec/example_beautified.rb
+++ b/spec/example_beautified.rb
@@ -69,11 +69,26 @@ else
 	puts 'not likely.'
 end
 
-#Test for different if statement formatting style(NOTE: it should not change this block at all)
-if 1 > 0 then puts 'something'
-elsif 2 < 0 then puts 'never!'
-else puts 'not likely.' end
-if 1 > 0 then puts 'something again' end
+class OneLiners
+	#Test for different if statement formatting style:
+	def no_change
+		if 1 > 0 then puts 'something'
+		elsif 2 < 0 then puts 'never!'
+		else puts 'not likely.' end
+		if 1 > 0 
+			if 1 == 1 then puts 'Hello' end
+		end
+	end
+	def change
+		if 1 > 0 then puts 'something'
+		elsif 2 < 0 then puts 'never!'
+		else puts 'not likely.' end
+		if 1 > 0 
+			if 1 == 1 then puts 'Hello' end
+		end
+	end
+end
+
 
 
 # Test for already indented blocks
@@ -151,3 +166,5 @@ def expensive_value
 		end
 	end
 end
+
+

--- a/spec/example_beautified.rb
+++ b/spec/example_beautified.rb
@@ -69,10 +69,11 @@ else
 	puts 'not likely.'
 end
 
-#Test for different if statement formatting style(NOTE: it should not change this block)
+#Test for different if statement formatting style(NOTE: it should not change this block at all)
 if 1 > 0 then puts 'something'
-elsif 1 < 0 then puts 'never!'
+elsif 2 < 0 then puts 'never!'
 else puts 'not likely.' end
+if 1 > 0 then puts 'something again' end
 
 
 # Test for already indented blocks

--- a/spec/example_beautified.rb
+++ b/spec/example_beautified.rb
@@ -69,6 +69,12 @@ else
 	puts 'not likely.'
 end
 
+#Test for different if statement formatting style(NOTE: it should not change this block)
+if 1 > 0 then puts 'something'
+elsif 1 < 0 then puts 'never!'
+else puts 'not likely.' end
+
+
 # Test for already indented blocks
 class There2 < There
 	def m1()


### PR DESCRIPTION
[Minimal example of the bug](https://gist.github.com/Sir-Irk/fdfd549d28f0e3f00e0e)
[Here is the bug when used on example.rb](https://gist.github.com/Sir-Irk/31baca0be48065ecfecd)(Start at line 72 for the OneLiners test I made). 
[This is what I'm getting with my hotfix](https://gist.github.com/Sir-Irk/1a05d0bfcc659f4bce45). 

It's a bit of a hack. opening_block?() has the change I made. Please let me know if I did anything stupid. I'm not very experienced with ruby and I don't have a thorough understanding of the program. I hope to at least point someone in the right direction. So far all of my tests in example.rb and files from a different project have worked but it probably isn't bug-free(I don't know the finer points of ruby syntax).