### PR TITLE
(fixed)Hotfix for bug with "else" and "end" on same line causing unwanted indentations

### DIFF
--- a/bin/ruby-beautify
+++ b/bin/ruby-beautify
@@ -103,11 +103,7 @@ end
 # kinda complex, we count open/close to determine if we ultimately have a
 # hanging line.   Always true if it's a both_block.
 def opening_block?(line_lex)
-  line_lex.each do |x|
-    return false if x[1] == :on_kw && @close_block.include?(x[2])
-  end
-  return true if both_block? line_lex
-  opens = starts_block?(line_lex) ? 1 : 0
+  opens = (starts_block?(line_lex) || both_block?(line_lex)) ? 1 : 0
   opens += opening_block_count line_lex
   closes = closing_block_count line_lex
   return false if opens == closes

--- a/bin/ruby-beautify
+++ b/bin/ruby-beautify
@@ -103,6 +103,11 @@ end
 # kinda complex, we count open/close to determine if we ultimately have a
 # hanging line.   Always true if it's a both_block.
 def opening_block?(line_lex)
+  line_lex.eache do |x|
+    if not x[1] == :on_sp
+      return false if x[1] == :on_we && @close_block.include?(x[2])
+    end
+  end
   return true if both_block? line_lex
   opens = starts_block?(line_lex) ? 1 : 0
   opens += opening_block_count line_lex

--- a/bin/ruby-beautify
+++ b/bin/ruby-beautify
@@ -103,9 +103,9 @@ end
 # kinda complex, we count open/close to determine if we ultimately have a
 # hanging line.   Always true if it's a both_block.
 def opening_block?(line_lex)
-  line_lex.eache do |x|
+  line_lex.each do |x|
     if not x[1] == :on_sp
-      return false if x[1] == :on_we && @close_block.include?(x[2])
+      return false if x[1] == :on_kw && @close_block.include?(x[2])
     end
   end
   return true if both_block? line_lex

--- a/bin/ruby-beautify
+++ b/bin/ruby-beautify
@@ -104,9 +104,7 @@ end
 # hanging line.   Always true if it's a both_block.
 def opening_block?(line_lex)
   line_lex.each do |x|
-    if not x[1] == :on_sp
-      return false if x[1] == :on_kw && @close_block.include?(x[2])
-    end
+    return false if x[1] == :on_kw && @close_block.include?(x[2])
   end
   return true if both_block? line_lex
   opens = starts_block?(line_lex) ? 1 : 0

--- a/spec/example.rb
+++ b/spec/example.rb
@@ -69,6 +69,12 @@ else
 puts 'not likely.'
 end
 
+#Test for different if-statement formatting
+if 1 > 0 then puts 'something'
+else puts 'nothing' end
+puts "This line should stay the same"
+	
+	
 # Test for already indented blocks
     class There2 < There
     def m1()

--- a/spec/example_beautified.rb
+++ b/spec/example_beautified.rb
@@ -69,6 +69,11 @@ else
 	puts 'not likely.'
 end
 
+#Test for different if-statement formatting
+if 1 > 0 then puts 'something'
+else puts 'nothing' end
+puts "This line should stay the same"
+
 # Test for already indented blocks
 class There2 < There
 	def m1()


### PR DESCRIPTION
[Minimal example of the bug](https://gist.github.com/Sir-Irk/fdfd549d28f0e3f00e0e)
opening_block?() has the change I made. There might be a better fix for this. Please let me know if I did anything stupid. I'm not very experienced with ruby and I don't have a thorough understanding of the program. I hope to at least point someone in the right direction. So far all of my tests in example.rb and files from a different project have worked but it probably isn't bug-free(I don't know the finer points of ruby syntax).