### PR TITLE
Fix auto indentation broken by lambda literal (-> (x) {x}).

### DIFF
--- a/lib/ruby-beautify.rb
+++ b/lib/ruby-beautify.rb
@@ -10,7 +10,7 @@ module RubyBeautify
 	OPEN_BLOCK_DO  = ['do', '{']
 	CLOSE_BLOCK = ['end', '}']
 
-	OPEN_BRACKETS  = [:on_lparen, :on_lbracket, :on_lbrace, :on_embexpr_beg]
+	OPEN_BRACKETS  = [:on_lparen, :on_lbracket, :on_lbrace, :on_embexpr_beg, :on_tlambeg]
 	CLOSE_BRACKETS = [:on_rparen, :on_rbracket, :on_rbrace, :on_embexpr_end]
 	NEW_LINES = [:on_nl, :on_ignored_nl, :on_comment, :on_embdoc_end]
 

--- a/spec/usage_scenarios/lambda_literal.rb
+++ b/spec/usage_scenarios/lambda_literal.rb
@@ -1,0 +1,34 @@
+# Test for lambda literal
+class ArrowOperator
+def one_liner
+x = -> (x) {x * x}
+end
+def one_liner2args
+x = -> (x, y) {x * y}
+end
+def multiline
+x = -> (x) {
+x * x
+}
+end
+def multiline2args
+x = -> (x, y) {
+x * y
+}
+end
+def omit_braces
+x = -> x {
+x * x
+}
+end
+def omit_braces2args
+x = -> x, y {
+x * y
+}
+end
+def argument_nothing
+x = -> {
+x * x
+}
+end
+end

--- a/spec/usage_scenarios/lambda_literal_pretty.rb
+++ b/spec/usage_scenarios/lambda_literal_pretty.rb
@@ -1,0 +1,34 @@
+# Test for lambda literal
+class ArrowOperator
+	def one_liner
+		x = -> (x) {x * x}
+	end
+	def one_liner2args
+		x = -> (x, y) {x * y}
+	end
+	def multiline
+		x = -> (x) {
+			x * x
+		}
+	end
+	def multiline2args
+		x = -> (x, y) {
+			x * y
+		}
+	end
+	def omit_braces
+		x = -> x {
+			x * x
+		}
+	end
+	def omit_braces2args
+		x = -> x, y {
+			x * y
+		}
+	end
+	def argument_nothing
+		x = -> {
+			x * x
+		}
+	end
+end


### PR DESCRIPTION
Ripper.lex was lambda literal parse to
on_tlambda = "->"
on_tlambeg = "{"
on_rbrace = "}".