### PR TITLE
Don't forget rest of code if there's no newline at the end. (fixes #23)

### DIFF
--- a/lib/ruby-beautify.rb
+++ b/lib/ruby-beautify.rb
@@ -24,9 +24,9 @@ module RubyBeautify
 		line_lex = []
 
 		# walk through line tokens
-		lex.each do |token|
+		lex.each_with_index do |token, i|
 			line_lex << token
-			if NEW_LINES.include? token[1] # if type of this token is a new line
+			if NEW_LINES.include?(token[1]) || i == lex.size-1 # if token is a new line or last token in list
 
 				# did we just close something?  if so, lets bring it down a level.
 				if closing_block?(line_lex) || closing_assignment?(line_lex)


### PR DESCRIPTION
This

```
require 'ruby-beautify'

content = "# Say hi to everybody
def say_hi
  if @names.nil?
    puts \"...\"
  elsif @names.respond_to?(\"each\")
    # @names is a list of some kind, iterate!
    @names.each do |name|
      puts \"Hello \#{name}!\"
    end
  else
    puts \"Hello \#{@names}!\"
  end
end"

print RubyBeautify.pretty_string content, indent_token: " ", indent_count: 2
```

will "forget" the final `end` because there is no new line at the end of the content.

This patch addresses this by making sure that the final token(s) don't get lost.